### PR TITLE
Remove duplication of valid options list

### DIFF
--- a/src/get-computer-choice.cr
+++ b/src/get-computer-choice.cr
@@ -1,5 +1,6 @@
+require "./valid-options"
+
 def get_computer_choice : String
-  valid_options = ["rock", "paper", "scissors"]
   random_index = Random.new.rand(3)
-  valid_options[random_index]
+  VALID_OPTIONS[random_index]
 end

--- a/src/input-validator.cr
+++ b/src/input-validator.cr
@@ -1,4 +1,5 @@
 require "./invalid-input-exception"
+require "./valid-options"
 
 module InputValidator
   extend self
@@ -17,9 +18,8 @@ module InputValidator
   end
 
   private def check_input_valid_option(input : String) : Nil
-    valid_inputs = ["rock", "paper", "scissors"]
     input_lowercased = input.downcase
-    if valid_inputs.none? { |option| option == input_lowercased }
+    if VALID_OPTIONS.none? { |option| option == input_lowercased }
       error_message = "Invalid input. You must input \"rock\", \"paper\" or \"scissors\" when prompted."
       raise InvalidInputException.new error_message
     end

--- a/src/valid-options.cr
+++ b/src/valid-options.cr
@@ -1,0 +1,1 @@
+VALID_OPTIONS = ["rock", "paper", "scissors"]


### PR DESCRIPTION
**Summary**
This PR refactors the codebase to use a single source for the list of valid options ("rock", "paper", or "scissors") rather than redeclaring the same array multiple times.

**Implementation Features**
- New `valid-options.cr` contains the `VALID_OPTIONS` constant which is set to the array `["rock", "paper", "scissors"]`.
- Refactor `InputValidator.check_input_valid_option` to use `VALID_OPTIONS`
- Refactor `get_computer_choice` to use `VALID_OPTIONS`

**Design Decisions**
I chose not to name the file containing the `VALID_OPTIONS` constant `constants.cr` because putting all of the constants into a single file can be considered bad practice. When all of the constants are in a single file it doesn't effectively separate the purposes of those constants or provide any information on what kind of constants the file contains when there's a lot of them. Nevertheless this project is probably only going to have one or two constants, so it doesn't actually matter that much.