### PR TITLE
Loop game on draw

### DIFF
--- a/src/main.cr
+++ b/src/main.cr
@@ -5,5 +5,5 @@ game_over = false
 while game_over == false
   player_choice = PlayerChoiceGetter.get
   computer_choice = get_computer_choice
-  game_over = player_choice.resolve_game computer_choice
+  game_over = player_choice.resolve_round computer_choice
 end

--- a/src/main.cr
+++ b/src/main.cr
@@ -1,6 +1,9 @@
 require "./player-choice-getter"
 require "./get-computer-choice"
 
-player_choice = PlayerChoiceGetter.get
-computer_choice = get_computer_choice
-player_choice.resolve_game computer_choice
+game_over = false
+while game_over == false
+  player_choice = PlayerChoiceGetter.get
+  computer_choice = get_computer_choice
+  game_over = player_choice.resolve_game computer_choice
+end

--- a/src/player-choices.cr
+++ b/src/player-choices.cr
@@ -3,13 +3,13 @@ abstract class PlayerChoice
   @@LOSES_AGAINST = ""
   @@IS = ""
 
-  def resolve_game(opponent_choice : String) : Bool
-    result = self.determine_game_result opponent_choice
-    self.display_game_info opponent_choice, result
+  def resolve_round(opponent_choice : String) : Bool
+    result = self.determine_round_result opponent_choice
+    self.display_round_info opponent_choice, result
     self.game_over? result
   end
 
-  private def determine_game_result(opponent_choice : String) : String
+  private def determine_round_result(opponent_choice : String) : String
     if opponent_choice == @@WINS_AGAINST
       return "win"
     elsif opponent_choice == @@LOSES_AGAINST
@@ -19,7 +19,7 @@ abstract class PlayerChoice
     end
   end
 
-  private def display_game_info(opponent_choice : String, result : String) : Nil
+  private def display_round_info(opponent_choice : String, result : String) : Nil
     puts "You chose: #{@@IS.capitalize}"
     puts "Opponent chose: #{opponent_choice.capitalize}"
     puts result == "draw" ? "It's a draw!" : "You #{result}!"

--- a/src/player-choices.cr
+++ b/src/player-choices.cr
@@ -3,9 +3,10 @@ abstract class PlayerChoice
   @@LOSES_AGAINST = ""
   @@IS = ""
 
-  def resolve_game(opponent_choice : String) : Nil
+  def resolve_game(opponent_choice : String) : Boolean
     result = self.determine_game_result opponent_choice
     self.display_game_info opponent_choice, result
+    self.game_over? result
   end
 
   private def determine_game_result(opponent_choice : String) : String
@@ -22,6 +23,10 @@ abstract class PlayerChoice
     puts "You chose: #{@@IS.capitalize}"
     puts "Opponent chose: #{opponent_choice.capitalize}"
     puts result == "draw" ? "It's a draw!" : "You #{result}!"
+  end
+
+  private def game_over?(result : String) : Boolean
+    result == "draw" ? false : true
   end
 end
 

--- a/src/player-choices.cr
+++ b/src/player-choices.cr
@@ -3,7 +3,7 @@ abstract class PlayerChoice
   @@LOSES_AGAINST = ""
   @@IS = ""
 
-  def resolve_game(opponent_choice : String) : Boolean
+  def resolve_game(opponent_choice : String) : Bool
     result = self.determine_game_result opponent_choice
     self.display_game_info opponent_choice, result
     self.game_over? result
@@ -25,7 +25,7 @@ abstract class PlayerChoice
     puts result == "draw" ? "It's a draw!" : "You #{result}!"
   end
 
-  private def game_over?(result : String) : Boolean
+  private def game_over?(result : String) : Bool
     result == "draw" ? false : true
   end
 end


### PR DESCRIPTION
**Summary**
This PR causes the game to play another round when there is a draw until either the player or the computer wins.

**Main Features**
- New `PlayerChoice.game_over?` accepts the game's result string and returns `false` if it's a draw and `true` otherwise.
- Rename `PlayerChoice.resolve_game` to `#resolve_round` and update it to return a `Boolean` which it gets by calling `#game_over?` and passing it the result.
- Update `main.cr` to loop the business logic until `PlayerChoice.resolve_round` returns `true`.

**Design Decisions**
I chose to implement the `while` loop in `main.cr` because the cyclic nature of game rounds in the occurrence of a draw is part of the business logic of the game.

Renaming and adding functionality to `#resolve_game` made sense because it already had access to the result of a round as a `String` so it was in a position to easily determine if the game should end.