### PR TITLE
Move error handling into main

### DIFF
--- a/src/main.cr
+++ b/src/main.cr
@@ -1,9 +1,14 @@
 require "./player-choice-getter"
 require "./get-computer-choice"
 
-game_over = false
-while game_over == false
-  player_choice = PlayerChoiceGetter.get
-  computer_choice = get_computer_choice
-  game_over = player_choice.resolve_round computer_choice
+begin
+  game_over = false
+  while game_over == false
+    player_choice = PlayerChoiceGetter.get
+    computer_choice = get_computer_choice
+    game_over = player_choice.resolve_round computer_choice
+  end
+rescue exception : InvalidInputException
+  puts exception.message
+  exit(1)
 end

--- a/src/player-choice-getter.cr
+++ b/src/player-choice-getter.cr
@@ -7,17 +7,13 @@ module PlayerChoiceGetter
 
   def get : PlayerChoice
     user_input = self.get_user_input
-    sanitised_user_input = self.sanitise_user_input user_input
+    sanitised_user_input = InputParser.parse user_input
     self.player_choice_factory sanitised_user_input
   end
 
   private def get_user_input : String?
     puts "Rock, Paper, or Scissors?:"
     input = gets
-  end
-
-  private def sanitise_user_input(user_input : String?) : String
-    InputParser.parse user_input
   end
 
   private def player_choice_factory(player_input : String?) : PlayerChoice

--- a/src/player-choice-getter.cr
+++ b/src/player-choice-getter.cr
@@ -17,12 +17,7 @@ module PlayerChoiceGetter
   end
 
   private def sanitise_user_input(user_input : String?) : String
-    begin
-      return InputParser.parse user_input
-    rescue exception : InvalidInputException
-      puts exception.message
-      exit(1)
-    end
+    InputParser.parse user_input
   end
 
   private def player_choice_factory(player_input : String?) : PlayerChoice


### PR DESCRIPTION
**Summary**
This PR moves the error handling that was in `PlayerChoiceGetter.sanitise_user_input` into `main.cr`. As a result the `#sanitise_user_input` method could be removed entirely.

**Design Decisions**
I moved the error handling into `main.cr` so that the call to `exit` isn't hidden in a lower level of the program. After that `PlayerChoiceGetter.sanitise_user_input` only contained a call to `InputParser.parse` so it could be inlined into the `#get` method which called it.