### PR TITLE
Throw exception when user input is nil

### DIFF
--- a/src/input-parser.cr
+++ b/src/input-parser.cr
@@ -4,19 +4,18 @@ require "./valid-options"
 module InputParser
   extend self
 
-  def parse(input : String?) : String
-    input = self.validate_not_empty_or_nil input
+  def parse(input : String) : String
+    self.validate_not_empty input
     input = input.strip.downcase
     self.validate_is_option input
     input
   end
 
-  private def validate_not_empty_or_nil(input : String?) : String
-    if input.nil? || input.empty?
+  private def validate_not_empty(input : String) : Nil
+    if input.empty?
       error_message = "No input. You must input \"rock\", \"paper\" or \"scissors\" when prompted."
       raise InvalidInputException.new error_message
     end
-    input
   end
 
   private def validate_is_option(input : String) : Nil

--- a/src/player-choice-getter.cr
+++ b/src/player-choice-getter.cr
@@ -11,9 +11,13 @@ module PlayerChoiceGetter
     self.player_choice_factory sanitised_user_input
   end
 
-  private def get_user_input : String?
+  private def get_user_input : String
     puts "Rock, Paper, or Scissors?:"
     input = gets
+    if input.nil?
+      raise Exception.new "Received Nil as user input"
+    end
+    input
   end
 
   private def player_choice_factory(player_input : String?) : PlayerChoice


### PR DESCRIPTION
**Summary**
This PR updates `PlayerChoiceGetter.get_user_input` to raise an exception if it receives `nil` as input. Then it refactors `InputParser` now that it doesn't have to deal with a `String | Nil` union type.

**Main Changes**
- Update `PlayerChoiceGetter.get_user_input` to raise an exception if the call to `gets` returns `nil`. This makes it always return a `String`
- Rename `InputParser.validate_not_empty_or_nil` to `#validate_not_empty`
- Update `InputParser.validate_not_empty` to stop checking for nil and returning the input `String`

**Design Decisions**
This change was done in order to clean up `InputParser.parse`. Previously the `#validate_not_empty_or_nil` method was returning the input parameter just to narrow the `String | Nil` union type for future operations in the `#parse` method. This will also allow a further refactoring where the sanitisation is done first and then all of the validation is encapsulated in a single private method.