### PR TITLE
Encapsulate input validation in InputParser

### DIFF
--- a/src/input-parser.cr
+++ b/src/input-parser.cr
@@ -5,9 +5,9 @@ module InputParser
   extend self
 
   def parse(input : String) : String
-    input = input.strip.downcase
-    self.validate input
-    input
+    sanitised_input = input.strip.downcase
+    self.validate sanitised_input
+    sanitised_input
   end
 
   private def validate(input : String) : Nil

--- a/src/input-parser.cr
+++ b/src/input-parser.cr
@@ -5,10 +5,14 @@ module InputParser
   extend self
 
   def parse(input : String) : String
-    self.validate_not_empty input
     input = input.strip.downcase
-    self.validate_is_option input
+    self.validate input
     input
+  end
+
+  private def validate(input : String) : Nil
+    self.validate_not_empty input
+    self.validate_is_option input
   end
 
   private def validate_not_empty(input : String) : Nil


### PR DESCRIPTION
This PR cleans up `InputParser.parse` by putting the input sanitisation first and then encapsulating all of the input validation in a single `#validate` method. It also makes the method use a new `sanitised_input` local variable rather than overwriting the `input` parameter.