### PR TITLE
Remove unused import

### DIFF
--- a/src/player-choice-getter.cr
+++ b/src/player-choice-getter.cr
@@ -1,6 +1,5 @@
 require "./player-choices"
 require "./input-parser"
-require "./invalid-input-exception"
 
 module PlayerChoiceGetter
   extend self


### PR DESCRIPTION
Remove unused import of `InvalidInputException` from `player-choice-getter.cr`.