### PR TITLE
Colourize shell messages

### DIFF
--- a/src/main.cr
+++ b/src/main.cr
@@ -1,3 +1,5 @@
+require "colorize"
+
 require "./player-choice-getter"
 require "./get-computer-choice"
 
@@ -9,6 +11,6 @@ begin
     game_over = player_choice.resolve_round computer_choice
   end
 rescue exception : InvalidInputException
-  puts exception.message
+  puts exception.message.colorize(:red)
   exit(1)
 end

--- a/src/player-choices.cr
+++ b/src/player-choices.cr
@@ -20,9 +20,13 @@ abstract class PlayerChoice
   end
 
   private def display_round_info(opponent_choice : String, result : String) : Nil
+    self.display_player_choices opponent_choice
+    self.display_round_result result
+  end
+
+  private def display_player_choices(opponent_choice : String) : Nil
     puts "You chose: #{@@IS.capitalize}"
     puts "Opponent chose: #{opponent_choice.capitalize}"
-    self.display_round_result result
   end
 
   private def display_round_result(result : String) : Nil

--- a/src/player-choices.cr
+++ b/src/player-choices.cr
@@ -22,7 +22,18 @@ abstract class PlayerChoice
   private def display_round_info(opponent_choice : String, result : String) : Nil
     puts "You chose: #{@@IS.capitalize}"
     puts "Opponent chose: #{opponent_choice.capitalize}"
-    puts result == "draw" ? "It's a draw!" : "You #{result}!"
+    self.display_round_result result
+  end
+
+  private def display_round_result(result : String) : Nil
+    case result
+    when "draw"
+      puts "It's a draw!".colorize(:yellow)
+    when "win"
+      puts "You win!".colorize(:green)
+    when "lose"
+      puts "You lose!".colorize(:red)
+    end
   end
 
   private def game_over?(result : String) : Bool


### PR DESCRIPTION
**Summary**
This PR uses the built in `colorize` module to add colour to some of the messaged displayed in the shell.

**Main Features**
- Update `main.cr` to colour `InputInvalidException` messages in red when they're logged to the console
- Update `PlayerChoice` to colourize the message displaying the result of the round. A win is in green, a lose is in red and a draw is in yellow

**Design Decisions**
I chose to use the `colorize` module rather than ANSI codes directly because it makes the code look cleaner. This would also be the more expected approach as the `colorize` module is part of the Crystal standard library.