### PR TITLE
Change draw message

### DIFF
--- a/src/player-choices.cr
+++ b/src/player-choices.cr
@@ -32,7 +32,7 @@ abstract class PlayerChoice
   private def display_round_result(result : String) : Nil
     case result
     when "draw"
-      puts "It's a draw!".colorize(:yellow)
+      puts "It's a draw, play again!".colorize(:yellow)
     when "win"
       puts "You win!".colorize(:green)
     when "lose"


### PR DESCRIPTION
Update `PlayerChoice.display_round_result` to change the draw message from `"It's a draw!"` to `"It's a draw, play again!"` to clarify that the game has automatically started another round.