### PR TITLE
Add a visual delay before displaying the result of a round

### DIFF
--- a/src/player-choices.cr
+++ b/src/player-choices.cr
@@ -5,6 +5,7 @@ abstract class PlayerChoice
 
   def resolve_round(opponent_choice : String) : Bool
     result = self.determine_round_result opponent_choice
+    self.delay_resolution
     self.display_round_info opponent_choice, result
     self.game_over? result
   end
@@ -17,6 +18,16 @@ abstract class PlayerChoice
     else
       return "draw"
     end
+  end
+
+  private def delay_resolution : Nil
+    count = 0
+    while count < 3
+      count += 1
+      printf "."
+      sleep 1
+    end
+    printf "\n"
   end
 
   private def display_round_info(opponent_choice : String, result : String) : Nil


### PR DESCRIPTION
**Summary**
This PR adds a delay between when the user inputs their choice and when a round is resolved in order to improve the feel of the game.

**Main Features**
- New `PlayerChoice.delay_resolution` delays the display of the result of the round by 3 seconds in total. It animates this by printing consecutive periods to the shell in 1 second intervals
- Update `PlayerChoice.resolve_round` to call `#delay_resolution` before the methods which show the result of the round to the player